### PR TITLE
Feature: Add support for -s flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ in the request file, replace the part where the payload is bing sent with {{num}
 From:
 
 ```http
-POST https://www.example.com/api/users HTTP/1.1
+POST /api/users HTTP/1.1
 Host: www.example.com
 Content-Type: application/json
 
@@ -26,7 +26,7 @@ Content-Type: application/json
 To:
 
 ```http
-POST https://www.example.com/api/users HTTP/1.1
+POST /api/users HTTP/1.1
 Host: www.example.com
 Content-Type: application/json
 
@@ -38,6 +38,7 @@ Content-Type: application/json
 
 - `-f <request filepath>` use this flag to specify the path of the request file 
 - `-e <error message>` the error message shown on incorrect attempt
+- `-s <stop message>` (optional) specify the expected message where you want the attack stop 
 - `-c <status code of error response>` the status code came with the error message in response
 - `-t <number of threads>` (optional) use this to add the number of threads you wanna run duruing the attack, default is 3
 - `-l <lenght of the number>` add the lenght of combinations to try
@@ -46,8 +47,12 @@ Content-Type: application/json
 example:
 
 ```bash
-python main.py -f post_req.http -e "invalid attempt" -c 401 -t 5 -l 4 
+python main.py -f post_req.http -e "invalid attempt" -s success -c 401 -t 5 -l 4 
 ```
 
-numberute will keep attacking long as it finds either the `error message` given or the `error status code` in the response. But, once it sees anything different, for example if the response status code changes or the if the server doesn't send the error in the response, numbrute stops there.
+numberute will keep sending payloads as long as: 
 
+- it finds either the `error message` given or the `error status code` in the response. 
+- or the response doesn't contain the expected message 
+
+numbrute stops the attack when the response doesn't match the above condition

--- a/assist.py
+++ b/assist.py
@@ -68,9 +68,10 @@ class Request:
 
 class Attack(Request):
     incorrect_num = True
-    def __init__(self,request_file_path,error_message=None,error_code=None,threads=3,disable_https=False):
+    def __init__(self,request_file_path,error_message=None, stop_message=None, error_code=None,threads=3,disable_https=False):
         super().__init__(request_file_path,disable_https)
         self.error_message = error_message
+        self.stop_message = stop_message
         self.error_code = error_code
         self.threads = threads
     
@@ -79,7 +80,10 @@ class Attack(Request):
         if self.error_message is not None and not self.error_message in response.text:
             self.incorrect_num = False
             return response
-        if self.error_code is not None and self.error_code != response.code:
+        elif self.stop_message is not None and self.stop_message in response.text:
+            self.incorrect_num = False
+            return response
+        elif self.error_code is not None and self.error_code != response.code:
             self.incorrect_num = False
             return response
 

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ parser = argparse.ArgumentParser(description='Numbrute')
 
 parser.add_argument('-f', '--file', type=str, required=True, help='Path to the file')
 parser.add_argument('-e', '--error_message', type=str, help='Error message')
+parser.add_argument('-s', '--stop_message', type=str, help='stop when response contains this message')
 parser.add_argument('-c', '--error_code', type=int, help='status code of response where the error message is shown')
 parser.add_argument('-t', '--threads', type=int, default=3, help='Number of threads')
 parser.add_argument('-l', '--length', type=int, default=4, help='Length of something')
@@ -33,13 +34,14 @@ for i in otpList:
     q.put(i)
 
 # Check if either error_message or error_code is provided
-if not (args.error_message or args.error_code):
-    parser.error('At least one of error_message or error_code must be provided.')
+if not (args.error_message or args.error_code or args.stop_message):
+    parser.error('At least one of error_message ,error_code or stop_message must be provided.')
 
 
 target = Attack(
     request_file_path=args.file,
     error_message=args.error_message,
+    stop_message=args.stop_message,
     error_code=args.error_code,
     threads=args.threads,
     disable_https=args.disable_https


### PR DESCRIPTION
Now, the user can specify a text which, if is present in the response, the attack stops
for example if I want the attack to stop when the response contains the text "success", the command would be:

```bash
python main.py -f request_file_path -s success
```
And ofcourse, you can use the other switches/flags as well to specify the length of the number or to control the number of threads